### PR TITLE
Add Possibility to Append Sensor Id to TF Client Frame

### DIFF
--- a/include/vrpn_client_ros/vrpn_client_ros.h
+++ b/include/vrpn_client_ros/vrpn_client_ros.h
@@ -81,6 +81,8 @@ namespace vrpn_client_ros
     ros::Publisher pose_pub, twist_pub, accel_pub;
     ros::NodeHandle output_nh_;
     bool use_server_time_, broadcast_tf_;
+    bool append_sensor_id_;
+    std::string tracker_name;
 
     ros::Timer mainloop_timer;
 

--- a/src/vrpn_client_ros.cpp
+++ b/src/vrpn_client_ros.cpp
@@ -77,12 +77,15 @@ namespace vrpn_client_ros
       return;
     }
 
+    this->tracker_name = tracker_name;
+    
     output_nh_ = ros::NodeHandle(nh, tracker_name);
 
     std::string frame_id;
     nh.param<std::string>("frame_id", frame_id, "world");
     nh.param<bool>("use_server_time", use_server_time_, false);
     nh.param<bool>("broadcast_tf", broadcast_tf_, false);
+    nh.param<bool>("append_sensor_id", append_sensor_id_, false);
 
     pose_msg_.header.frame_id = twist_msg_.header.frame_id = accel_msg_.header.frame_id = transform_stamped_.header.frame_id = frame_id;
     transform_stamped_.child_frame_id = tracker_name;
@@ -154,6 +157,18 @@ namespace vrpn_client_ros
       {
         tracker->transform_stamped_.header.stamp = ros::Time::now();
       }
+
+      if (tracker->append_sensor_id_)
+      {
+        std::stringstream ss;
+        ss << tracker->tracker_name << "_" << tracker_pose.sensor;
+        tracker->transform_stamped_.child_frame_id = ss.str().c_str();
+      }
+      else
+      {
+        tracker->transform_stamped_.child_frame_id = tracker->tracker_name;
+      }
+      
       tracker->transform_stamped_.transform.translation.x = tracker_pose.pos[0];
       tracker->transform_stamped_.transform.translation.y = tracker_pose.pos[1];
       tracker->transform_stamped_.transform.translation.z = tracker_pose.pos[2];


### PR DESCRIPTION
A VRPN "tracker" can have multiple tracked frames, each being a separate "sensor" in the VRPN API. In our project we have two sensors on one tracker and need to be able to read these off separately. The pull request adds a parameter "append_sensor_id" that when set to true makes the client append the sensor id to the tracker name before submitting the pose to the tf topic.

This pull request corresponds to issue #1 
