### PR TITLE
Add cmake modules for VRPN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(vrpn_client_ros)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs roscpp roslaunch roslint tf2_ros)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 find_package(VRPN REQUIRED)
 
 catkin_package(

--- a/cmake/Modules/FindVRPN.cmake
+++ b/cmake/Modules/FindVRPN.cmake
@@ -1,0 +1,156 @@
+# - try to find VRPN library
+#
+# Cache Variables:
+#  VRPN_LIBRARY
+#  VRPN_SERVER_LIBRARY
+#  VRPN_INCLUDE_DIR
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  VRPN_FOUND
+#  VRPN_SERVER_LIBRARIES - server libraries
+#  VRPN_LIBRARIES - client libraries
+#  VRPN_CLIENT_DEFINITIONS - definitions if you only use the client library
+#  VRPN_DEFINITIONS - Client-only definition if all we found was the client library.
+#  VRPN_INCLUDE_DIRS
+#
+# VRPN_ROOT_DIR is searched preferentially for these files
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2009-2012 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2012.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(VRPN_ROOT_DIR
+	"${VRPN_ROOT_DIR}"
+	CACHE
+	PATH
+	"Root directory to search for VRPN")
+
+if("${CMAKE_SIZEOF_VOID_P}" MATCHES "8")
+	set(_libsuffixes lib64 lib)
+
+	# 64-bit dir: only set on win64
+	file(TO_CMAKE_PATH "$ENV{ProgramW6432}" _progfiles)
+else()
+	set(_libsuffixes lib)
+	set(_PF86 "ProgramFiles(x86)")
+	if(NOT "$ENV{${_PF86}}" STREQUAL "")
+		# 32-bit dir: only set on win64
+		file(TO_CMAKE_PATH "$ENV{${_PF86}}" _progfiles)
+	else()
+		# 32-bit dir on win32, useless to us on win64
+		file(TO_CMAKE_PATH "$ENV{ProgramFiles}" _progfiles)
+	endif()
+endif()
+
+set(_vrpn_quiet)
+if(VRPN_FIND_QUIETLY)
+	set(_vrpn_quiet QUIET)
+endif()
+
+###
+# Configure VRPN
+###
+
+find_path(VRPN_INCLUDE_DIR
+	NAMES
+	vrpn_Connection.h
+	PATH_SUFFIXES
+	include
+	include/vrpn
+	HINTS
+	"${VRPN_ROOT_DIR}"
+	PATHS
+	"${_progfiles}/VRPN"
+	C:/usr/local
+	/usr/local)
+
+find_library(VRPN_LIBRARY
+	NAMES
+	vrpn
+	PATH_SUFFIXES
+	${_libsuffixes}
+	HINTS
+	"${VRPN_ROOT_DIR}"
+	PATHS
+	"${_progfiles}/VRPN"
+	C:/usr/local
+	/usr/local)
+
+find_library(VRPN_SERVER_LIBRARY
+	NAMES
+	vrpnserver
+	PATH_SUFFIXES
+	${_libsuffixes}
+	HINTS
+	"${VRPN_ROOT_DIR}"
+	PATHS
+	"${_progfiles}/VRPN"
+	C:/usr/local
+	/usr/local)
+
+###
+# Dependencies
+###
+set(_deps_libs)
+set(_deps_includes)
+set(_deps_check)
+
+find_package(quatlib ${_vrpn_quiet})
+list(APPEND _deps_libs ${QUATLIB_LIBRARIES})
+list(APPEND _deps_includes ${QUATLIB_INCLUDE_DIRS})
+list(APPEND _deps_check QUATLIB_FOUND)
+
+if(NOT WIN32)
+	find_package(Threads ${_vrpn_quiet})
+	list(APPEND _deps_libs ${CMAKE_THREAD_LIBS_INIT})
+	list(APPEND _deps_check CMAKE_HAVE_THREADS_LIBRARY)
+endif()
+
+if(WIN32)
+	find_package(Libusb1 ${_vrpn_quiet})
+	if(LIBUSB1_FOUND)
+		list(APPEND _deps_libs ${LIBUSB1_LIBRARIES})
+		list(APPEND _deps_includes ${LIBUSB1_INCLUDE_DIRS})
+	endif()
+endif()
+
+
+# handle the QUIETLY and REQUIRED arguments and set xxx_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(VRPN
+	DEFAULT_MSG
+	VRPN_LIBRARY
+	VRPN_INCLUDE_DIR
+	${_deps_check})
+
+if(VRPN_FOUND)
+	set(VRPN_INCLUDE_DIRS "${VRPN_INCLUDE_DIR}" ${_deps_includes})
+	set(VRPN_LIBRARIES "${VRPN_LIBRARY}" ${_deps_libs})
+	set(VRPN_SERVER_LIBRARIES "${VRPN_SERVER_LIBRARY}" ${_deps_libs})
+
+	if(VRPN_LIBRARY)
+		set(VRPN_CLIENT_DEFINITIONS -DVRPN_CLIENT_ONLY)
+	else()
+		unset(VRPN_CLIENT_DEFINITIONS)
+	endif()
+
+	if(VRPN_LIBRARY AND NOT VRPN_SERVER_LIBRARY)
+		set(VRPN_DEFINITIONS -DVRPN_CLIENT_ONLY)
+	else()
+		unset(VRPN_DEFINITIONS)
+	endif()
+
+	mark_as_advanced(VRPN_ROOT_DIR)
+endif()
+
+mark_as_advanced(VRPN_LIBRARY VRPN_SERVER_LIBRARY VRPN_INCLUDE_DIR)

--- a/cmake/Modules/Findquatlib.cmake
+++ b/cmake/Modules/Findquatlib.cmake
@@ -1,0 +1,104 @@
+# - Find quatlib
+# Find the quatlib headers and libraries.
+#
+#  QUATLIB_INCLUDE_DIRS - where to find quat.h
+#  QUATLIB_LIBRARIES    - List of libraries when using quatlib.
+#  QUATLIB_FOUND        - True if quatlib found.
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(TARGET quat)
+	# Look for the header file.
+	find_path(QUATLIB_INCLUDE_DIR NAMES quat.h
+			PATHS ${quatlib_SOURCE_DIR})
+
+	set(QUATLIB_LIBRARY "quat")
+
+else()
+	set(QUATLIB_ROOT_DIR
+		"${QUATLIB_ROOT_DIR}"
+		CACHE
+		PATH
+		"Root directory to search for quatlib")
+	if(DEFINED VRPN_ROOT_DIR AND NOT QUATLIB_ROOT_DIR)
+		set(QUATLIB_ROOT_DIR "${VRPN_ROOT_DIR}")
+		mark_as_advanced(QUATLIB_ROOT_DIR)
+	endif()
+
+	if("${CMAKE_SIZEOF_VOID_P}" MATCHES "8")
+		set(_libsuffixes lib64 lib)
+
+		# 64-bit dir: only set on win64
+		file(TO_CMAKE_PATH "$ENV{ProgramW6432}" _progfiles)
+	else()
+		set(_libsuffixes lib)
+		set(_PF86 "ProgramFiles(x86)")
+		if(NOT "$ENV{${_PF86}}" STREQUAL "")
+			# 32-bit dir: only set on win64
+			file(TO_CMAKE_PATH "$ENV{${_PF86}}" _progfiles)
+		else()
+			# 32-bit dir on win32, useless to us on win64
+			file(TO_CMAKE_PATH "$ENV{ProgramFiles}" _progfiles)
+		endif()
+	endif()
+
+	# Look for the header file.
+	find_path(QUATLIB_INCLUDE_DIR
+		NAMES
+		quat.h
+		HINTS
+		"${QUATLIB_ROOT_DIR}"
+		PATH_SUFFIXES
+		include
+		PATHS
+		"${_progfiles}/VRPN"
+		"${_progfiles}/quatlib"
+		C:/usr/local
+		/usr/local)
+
+	# Look for the library.
+	find_library(QUATLIB_LIBRARY
+		NAMES
+		quat.lib
+		libquat.a
+		HINTS
+		"${QUATLIB_ROOT_DIR}"
+		PATH_SUFFIXES
+		${_libsuffixes}
+		PATHS
+		"${_progfiles}/VRPN"
+		"${_progfiles}/quatlib"
+		C:/usr/local
+		/usr/local)
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set QUATLIB_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(quatlib
+	DEFAULT_MSG
+	QUATLIB_LIBRARY
+	QUATLIB_INCLUDE_DIR)
+
+if(QUATLIB_FOUND)
+	set(QUATLIB_LIBRARIES ${QUATLIB_LIBRARY})
+	if(NOT WIN32)
+		list(APPEND QUATLIB_LIBRARIES m)
+	endif()
+	set(QUATLIB_INCLUDE_DIRS ${QUATLIB_INCLUDE_DIR})
+
+	mark_as_advanced(QUATLIB_ROOT_DIR)
+else()
+	set(QUATLIB_LIBRARIES)
+	set(QUATLIB_INCLUDE_DIRS)
+endif()
+
+mark_as_advanced(QUATLIB_LIBRARY QUATLIB_INCLUDE_DIR)


### PR DESCRIPTION
When compiling the node for Kinetic, I saw that doing a _make install_ of VRPN does not install the cmake config/find library files which are needed to compile the node. Thus, I think it makes sense to include them with the node source code.
