### PR TITLE
fix: motive auto generated names are not valid ROS identifiers: "Rigidy Body n"

### DIFF
--- a/src/vrpn_client_ros.cpp
+++ b/src/vrpn_client_ros.cpp
@@ -68,12 +68,14 @@ namespace vrpn_client_ros
 
     if (clean_name.size() > 0)
     {
+      int start_subsequent = 1;
       if (isInvalidFirstCharInName(clean_name[0])) 
       {
         clean_name = clean_name.substr(1);
+        start_subsequent = 0;
       }
 
-      clean_name.erase( std::remove_if( clean_name.begin() + 1, clean_name.end(), isInvalidSubsequentCharInName ), clean_name.end() );
+      clean_name.erase( std::remove_if( clean_name.begin() + start_subsequent, clean_name.end(), isInvalidSubsequentCharInName ), clean_name.end() );
     }
 
     init(clean_name, nh, false);

--- a/src/vrpn_client_ros.cpp
+++ b/src/vrpn_client_ros.cpp
@@ -50,7 +50,12 @@ namespace vrpn_client_ros
   /**
    * check Ros Names as defined here: http://wiki.ros.org/Names
    */
-  bool isInvalidCharInName(const char c)
+  bool isInvalidFirstCharInName(const char c)
+  {
+    return ! ( isalpha(c) || c == '/' || c == '~' );
+  }
+
+  bool isInvalidSubsequentCharInName(const char c)
   {
     return ! ( isalnum(c) || c == '/' || c == '_' );
   }
@@ -61,8 +66,15 @@ namespace vrpn_client_ros
 
     std::string clean_name = tracker_name;
 
-    //clean_name.erase( std::remove( clean_name.begin(), clean_name.end(), ' '), clean_name.end() );  //only remove spaces
-    clean_name.erase( std::remove_if( clean_name.begin(), clean_name.end(), isInvalidCharInName ), clean_name.end() );
+    if (clean_name.size() > 0)
+    {
+      if (isInvalidFirstCharInName(clean_name[0])) 
+      {
+        clean_name = clean_name.substr(1);
+      }
+
+      clean_name.erase( std::remove_if( clean_name.begin() + 1, clean_name.end(), isInvalidSubsequentCharInName ), clean_name.end() );
+    }
 
     init(clean_name, nh, false);
   }

--- a/src/vrpn_client_ros.cpp
+++ b/src/vrpn_client_ros.cpp
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <unordered_set>
+#include <algorithm>
 
 namespace
 {
@@ -46,10 +47,24 @@ namespace
 namespace vrpn_client_ros
 {
 
+  /**
+   * check Ros Names as defined here: http://wiki.ros.org/Names
+   */
+  bool isInvalidCharInName(const char c)
+  {
+    return ! ( isalnum(c) || c == '/' || c == '_' );
+  }
+
   VrpnTrackerRos::VrpnTrackerRos(std::string tracker_name, ConnectionPtr connection, ros::NodeHandle nh)
   {
     tracker_remote_ = std::make_shared<vrpn_Tracker_Remote>(tracker_name.c_str(), connection.get());
-    init(tracker_name, nh, false);
+
+    std::string clean_name = tracker_name;
+
+    //clean_name.erase( std::remove( clean_name.begin(), clean_name.end(), ' '), clean_name.end() );  //only remove spaces
+    clean_name.erase( std::remove_if( clean_name.begin(), clean_name.end(), isInvalidCharInName ), clean_name.end() );
+
+    init(clean_name, nh, false);
   }
 
   VrpnTrackerRos::VrpnTrackerRos(std::string tracker_name, std::string host, ros::NodeHandle nh)


### PR DESCRIPTION
Removes spaces and other invalid characters from rigid body names streamed from Motive.

Old behavior: No TF is published if the rigid body name is invalid.